### PR TITLE
fixed name padding and improved longname support

### DIFF
--- a/source/views/layout/_header.html
+++ b/source/views/layout/_header.html
@@ -44,17 +44,14 @@
 						<img class="" src="<%=user.avatar_url %>" alt="<%=user.name%>"/>
 					</span>
 				</div>
-				<div class="menu menu-sub menu-sub-dropdown menu-column menu-rounded menu-gray-600 menu-state-bg-light-primary fw-bold w-200px " data-kt-menu="true" style="margin: 0px; z-index: 105; position: fixed; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate3d(550px, 78px, 0px);" data-popper-placement="bottom-end">
-					<div class="menu-content fw-bold d-flex align-items-center bgi-no-repeat bgi-position-y-top rounded-top bg-info" >
-						<div class="symbol symbol-45px mx-5 py-5">
+				<div class="menu menu-sub menu-sub-dropdown menu-column menu-rounded menu-gray-600 menu-state-bg-light-primary fw-bold w-225px " data-kt-menu="true" style="margin: 0px; z-index: 105; position: fixed; left: 0px; top: 0px; right: auto; bottom: auto; transform: translate3d(550px, 78px, 0px);" data-popper-placement="bottom-end">
+					<div class="menu-content fw-bold d-flex align-items-center bgi-no-repeat bgi-position-y-top rounded-top bg-info p-2">
+						<div class="symbol symbol-45px mx-1 py-1">
 							<span class="symbol symbol-40px">
 								<img src="<%=user.avatar_url %>" alt="<%=user.name%>"/>
 							</span>
 						</div>
-						<div class="">
-							<span class="text-white fw-bolder fs-4">Hello, <%=user.name%></span>
-							<span class="text-white fw-bold fs-7 d-block"></span>
-						</div>
+						<span class="text-white fw-bolder fs-4 mx-auto">Hello, <%=user.name%></span>
 					</div>
 					<!--begin::Row-->
 					<div class="row row-cols-2 g-0">


### PR DESCRIPTION
I added padding so that names do not run to the end of the container.

I also changed some of the spacing so that the text area is larger. This helps with longer names.

![image](https://user-images.githubusercontent.com/12960453/111546108-82b40700-874d-11eb-953c-5272d6ac3a05.png)
